### PR TITLE
Update README.md

### DIFF
--- a/PowerView/README.md
+++ b/PowerView/README.md
@@ -13,7 +13,7 @@ on the domain the current user has local administrator access on. See function
 descriptions for appropriate usage and available options.
 
 To run on a machine, start PowerShell with "powershell -exec bypass" and then load
-the powerview script: PS> Import-Module .\powerview.ps1
+the powerview script: PS> Import-Module .\powerview.psm1
 
 For detailed output of underlying functionality, pass the -Debug flag to most functions.
 


### PR DESCRIPTION
Shouldn't the command to load the powerview module should point to the script module file?

For example:

    PS > Import-Module .\powerview.ps1
    PS > Get-Command -Module powerview
    PS >

vs

    PS > Import-Module .\powerview.psm1
    PS > Get-Command -Module powerview
    
    CommandType     Name                            Definition
    -----------     ----                            ----------
    Function        Add-Win32Type                   ...
    Function        Export-CSV                      ...
    Function        field                           ...
    Function        func                            ...
    Function        Get-ComputerProperties          ...
    Function        Get-HostIP                      ...
    Function        Get-LastLoggedOn                ...
    Function        Get-NetComputers                ...
    Function        Get-NetConnections              ...
    <snip>