### PR TITLE
Changed Parsing Method in Invoke-MassMimikatz

### DIFF
--- a/PewPewPew/Invoke-MassMimikatz.ps1
+++ b/PewPewPew/Invoke-MassMimikatz.ps1
@@ -26,10 +26,11 @@ function Parse-Mimikatz {
     )
     
     # msv
-    if($raw -match '(?s)(?<=msv :).*?(?=tspkg :)'){
-        foreach($match in $Matches){
-            if($match[0].Contains("Domain")){
-                $lines = $match[0].split("`n")
+	$results = $raw | Select-String -Pattern "(?s)(?<=msv :).*?(?=tspkg :)" -AllMatches | %{$_.matches} | %{$_.value}
+    if($results){
+        foreach($match in $results){
+            if($match.Contains("Domain")){
+                $lines = $match.split("`n")
                 foreach($line in $lines){
                     if ($line.Contains("Username")){
                         $username = $line.split(":")[1].trim()
@@ -47,11 +48,11 @@ function Parse-Mimikatz {
             }
         }
     }
-
-    if($raw -match '(?s)(?<=tspkg :).*?(?=wdigest :)'){
-        foreach($match in $Matches){
-            if($match[0].Contains("Domain")){
-                $lines = $match[0].split("`n")
+    $results = $raw | Select-String -Pattern "(?s)(?<=tspkg :).*?(?=wdigest :)" -AllMatches | %{$_.matches} | %{$_.value}
+    if($results){
+        foreach($match in $results){
+            if($match.Contains("Domain")){
+                $lines = $match.split("`n")
                 foreach($line in $lines){
                     if ($line.Contains("Username")){
                         $username = $line.split(":")[1].trim()
@@ -69,11 +70,11 @@ function Parse-Mimikatz {
             }
         }
     }
-
-    if($raw -match '(?s)(?<=wdigest :).*?(?=kerberos :)'){
-        foreach($match in $Matches){
-            if($match[0].Contains("Domain")){
-                $lines = $match[0].split("`n")
+    $results = $raw | Select-String -Pattern "(?s)(?<=wdigest :).*?(?=kerberos :)" -AllMatches | %{$_.matches} | %{$_.value}
+    if($results){
+        foreach($match in $results){
+            if($match.Contains("Domain")){
+                $lines = $match.split("`n")
                 foreach($line in $lines){
                     if ($line.Contains("Username")){
                         $username = $line.split(":")[1].trim()
@@ -91,11 +92,11 @@ function Parse-Mimikatz {
             }
         }
     }
-
-    if($raw -match '(?s)(?<=kerberos :).*?(?=ssp :)'){
-        foreach($match in $Matches){
-            if($match[0].Contains("Domain")){
-                $lines = $match[0].split("`n")
+    $results = $raw | Select-String -Pattern "(?s)(?<=kerberos :).*?(?=ssp :)" -AllMatches | %{$_.matches} | %{$_.value}
+    if($results){
+        foreach($match in $results){
+            if($match.Contains("Domain")){
+                $lines = $match.split("`n")
                 foreach($line in $lines){
                     if ($line.Contains("Username")){
                         $username = $line.split(":")[1].trim()


### PR DESCRIPTION
Updated the method that the Parse-Mimikatz function uses to parse through the Mimikatz output. Currently, it uses -match to search for the sections within the output. -match is limited to the first match and stops when it finds it, meaning it won't display other credentials in the Mimikatz output.

I updated that function to use Select-String instead, which will show all matches instead of the first one. The two images show a before and after of the output.
![currently](https://cloud.githubusercontent.com/assets/6264733/6986659/755ea180-da0d-11e4-909e-983760923711.png)
![afterupdate](https://cloud.githubusercontent.com/assets/6264733/6986663/78247cc8-da0d-11e4-8a76-4d963bcfba74.png)
